### PR TITLE
Add My Express Server with Docker support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,13 @@ services:
       - 8000:8000
     volumes:
       - ./python-server/src:/app/src
+
+  my-express-server:
+    build:
+      context: ./my-express-server
+      dockerfile: Dockerfile
+    ports:
+      - 8001:8001
+    volumes:
+      - ./my-express-server/src:/usr/src/app/src
+    command: yarn start

--- a/my-express-server/Dockerfile
+++ b/my-express-server/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:14
+
+# Set the working directory
+WORKDIR /usr/src/app
+
+# Copy package.json and yarn.lock
+COPY package.json yarn.lock ./
+
+# Install dependencies
+RUN yarn install
+
+# Copy the rest of the application code
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 8001
+
+# Command to run the app
+CMD ["yarn", "start"]

--- a/my-express-server/README.md
+++ b/my-express-server/README.md
@@ -1,0 +1,51 @@
+# My Express Server
+
+This is a simple Express server project that listens on port 8001. It is set up to use Nodemon for automatic code reloading during development.
+
+## Getting Started
+
+To get started with this project, follow the instructions below:
+
+### Prerequisites
+
+Make sure you have [Node.js](https://nodejs.org/) and [Yarn](https://yarnpkg.com/) installed on your machine.
+
+### Installation
+
+1. Clone the repository:
+   ```
+   git clone <repository-url>
+   cd my-express-server
+   ```
+
+2. Install the dependencies:
+   ```
+   yarn install
+   ```
+
+### Running the Server
+
+To start the server with automatic reloading, use the following command:
+```
+yarn start
+```
+
+The server will be running on [http://localhost:8001](http://localhost:8001).
+
+### Docker
+
+To build and run the server using Docker, follow these steps:
+
+1. Build the Docker image:
+   ```
+   docker build -t my-express-server .
+   ```
+
+2. Run the Docker container:
+   ```
+   docker run -p 8001:8001 my-express-server
+   ```
+
+### License
+
+This project is licensed under the MIT License.

--- a/my-express-server/package.json
+++ b/my-express-server/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "my-express-server",
+  "version": "1.0.0",
+  "description": "A simple Express server that listens on port 8001.",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "nodemon src/index.js"
+  },
+  "dependencies": {
+    "express": "^4.17.1"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.7"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/my-express-server/src/index.js
+++ b/my-express-server/src/index.js
@@ -1,0 +1,8 @@
+const express = require('express');
+
+const app = express();
+const PORT = 8001;
+
+app.listen(PORT, () => {
+    console.log(`Server is running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
Introduce a new Express server project with Docker configuration, including a Dockerfile, README, and necessary package files. The server listens on port 8001 and supports automatic reloading during development.